### PR TITLE
feat: Memory JSONL Visualizer MVP

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "env": {
+        "MEMORY_FILE_PATH": "${PWD}/memory.jsonl"
+      }
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-03-28
+
+### Added
+- HTML/CSS framework with light theme and full-screen SVG layout
+- Control panels: search, details view, legend, statistics
+- DataModel for JSONL/JSON parsing with exact-string deduplication
+- Merge logic for duplicate entities (Set-based)
+- Relation deduplication and ghost-node generation for dangling references
+- D3 v7 force-directed graph visualization
+- Dynamic Tableau10 color palette for entity types
+- Shortened arrows (dynamic refX) with direction indicators
+- Ghost nodes (dashed stroke) for dangling references
+- Duplicate indicators (thick stroke) with count badges
+- Interactive detail panel with clickable relations for graph navigation
+- Neighbor highlighting and dimming on node selection
+- Full-text search with type filtering
+- Keyboard navigation (Escape to deselect)
+- Graph statistics (entity/relation/type counts)
+- JSONL export functionality
+- Fit-to-view on simulation end
+- Document-level drag-and-drop file loading
+- Bug fix: fitToView called once instead of after every drag
+- Bug fix: Improved relation items layout (two-line format: entity + relation type)
+
+### Fixed
+- Crash from dangling relations (now handled with ghost-nodes)
+- Duplicate nodes appearing multiple times (now merged with count tracking)
+- Arrow positioning with hardcoded refX (now dynamically calculated)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Relation deduplication and ghost-node generation for dangling references
 - D3 v7 force-directed graph visualization
 - Dynamic Tableau10 color palette for entity types
-- Shortened arrows (dynamic refX) with direction indicators
+- Arrows shortened to node boundaries in ticked() with fixed small marker refX
 - Ghost nodes (dashed stroke) for dangling references
-- Duplicate indicators (thick stroke) with count badges
+- Duplicate indicators (thick stroke) with info in detail panel
 - Interactive detail panel with clickable relations for graph navigation
 - Neighbor highlighting and dimming on node selection
 - Full-text search with type filtering
@@ -45,4 +45,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Crash from dangling relations (now handled with ghost-nodes)
 - Duplicate nodes appearing multiple times (now merged with count tracking)
-- Arrow positioning with hardcoded refX (now dynamically calculated)
+- Arrow positioning with hardcoded refX=25 (now lines shortened to node boundary in ticked(), marker uses fixed small refX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.1] — 2026-03-28
+
+### Fixed
+- fitToView now called only once on initial load instead of after every drag (added `fitted` flag)
+
+### Changed
+- Duplicate and relation item layout: two-line format displays entity name (line 1, clickable) and relationType (line 2, smaller font) to prevent text truncation on long relation types
+- DataModel now preserves original versions of duplicates in `_versions` array (entityType and observations)
+
+### Added
+- Clickable duplicate version viewer: "Found N times — show versions" in detail panel reveals all original records with their entityType and observations
+- Clickable filters in statistics panel: clicking "N dup" or "N ghost" filters graph to show only duplicates or ghost nodes; clicking again resets filter
+- Test data updated: memory.jsonl expanded with duplicate entities having different entityType/observations and additional ghost node relationships
+
 ## [0.1.0] — 2026-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reverse-engineered from [mcp-memory-visualizer](https://github.com/dzivkovi/mcp-
 
 ## Version
 
-Version: **0.1.0** ([changelog](CHANGELOG.md))
+Version: **0.1.1** ([changelog](CHANGELOG.md))
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# Memory JSONL Visualizer & Editor
+
+Web-based visualizer and editor for MCP server-memory JSONL files. Interactive graph visualization with D3.js v7, full-text search, entity/relation management, and export capabilities.
+
+Reverse-engineered from [mcp-memory-visualizer](https://github.com/dzivkovi/mcp-memory-visualizer) with bug fixes and enhancements.
+
+## Version
+
+Version: **0.1.0** ([changelog](CHANGELOG.md))
+
+## Features
+
+- **Graph Visualization**: D3.js force-directed layout with dynamic entity type coloring
+- **Interactive Navigation**: Click entities to view details, hover to highlight neighbors
+- **Search & Filter**: Full-text search with type filtering
+- **Duplicate Detection**: Identifies and merges duplicate entities, shows count badges
+- **Dangling References**: Handles unresolved relations with ghost-nodes
+- **Data Export**: Export current graph state as JSONL
+- **Statistics**: Entity, relation, and type counts
+- **Keyboard Support**: Escape to deselect nodes
+
+## Quick Start
+
+1. Open `index.html` in a modern web browser
+2. Load a JSONL file via drag-and-drop or file input
+3. Click nodes to view entity details and connected relations
+4. Use search box to filter by name or type
+5. Export modified graph as JSONL
+
+## File Format
+
+The visualizer accepts standard MCP server-memory JSONL files:
+
+```jsonl
+{"type": "entity", "name": "Node Name", "entityType": "category"}
+{"type": "relation", "from": "Node Name", "to": "Target Name", "relationType": "connects_to"}
+{"type": "observation", "entityName": "Node Name", "contents": ["fact 1", "fact 2"]}
+```
+
+## Requirements
+
+- Modern web browser (Chrome, Firefox, Safari, Edge)
+- JavaScript enabled
+- D3.js v7 (loaded from CDN)
+
+## Architecture
+
+- **DataModel**: Parses and manages JSONL data, handles deduplication and merging
+- **Renderer**: D3.js-based SVG graph visualization with force simulation
+- **UI**: Search, detail panel, legend, statistics, drag-and-drop file loading
+
+## Agents & Automation
+
+- Memory MCP Client: Integrates with MCP server-memory for real-time graph updates
+- GitHub Issues: [Issue #7](https://github.com/oshliaer/server-memory-editor/issues/7) (umbrella), #1-#6 (phase 1), #8-#9 (interactive filtering)
+
+## Configuration
+
+- **Color Scheme**: Tableau10 dynamic palette for entity types
+- **Force Simulation**: D3 force parameters (charge, link distance) are auto-tuned
+- **Graph Bounds**: Fit-to-view automatically after simulation stabilization
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Version: **0.1.1** ([changelog](CHANGELOG.md))
 - **Duplicate Detection**: Identifies and merges duplicate entities with version tracking
 - **Dangling References**: Handles unresolved relations with ghost-nodes
 - **Data Export**: Export current graph state as JSONL
-- **Statistics**: Entity, relation, and type counts
+- **Statistics**: Entity and relation counts with duplicate/ghost filters
 - **Keyboard Support**: Escape to deselect nodes
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memory JSONL Visualizer & Editor
 
-Web-based visualizer and editor for MCP server-memory JSONL files. Interactive graph visualization with D3.js v7, full-text search, entity/relation management, and export capabilities.
+Web-based visualizer for [MCP server-memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) JSONL files. Interactive graph visualization with D3.js v7, full-text search, and export capabilities. Editing features are planned for future phases.
 
 Reverse-engineered from [mcp-memory-visualizer](https://github.com/dzivkovi/mcp-memory-visualizer) with bug fixes and enhancements.
 
@@ -11,9 +11,9 @@ Version: **0.1.1** ([changelog](CHANGELOG.md))
 ## Features
 
 - **Graph Visualization**: D3.js force-directed layout with dynamic entity type coloring
-- **Interactive Navigation**: Click entities to view details, hover to highlight neighbors
-- **Search & Filter**: Full-text search with type filtering
-- **Duplicate Detection**: Identifies and merges duplicate entities, shows count badges
+- **Interactive Navigation**: Click entities to view details and highlight neighbors
+- **Search**: Full-text search across name, entity type, and observations
+- **Duplicate Detection**: Identifies and merges duplicate entities with version tracking
 - **Dangling References**: Handles unresolved relations with ghost-nodes
 - **Data Export**: Export current graph state as JSONL
 - **Statistics**: Entity, relation, and type counts
@@ -29,13 +29,14 @@ Version: **0.1.1** ([changelog](CHANGELOG.md))
 
 ## File Format
 
-The visualizer accepts standard MCP server-memory JSONL files:
+The visualizer accepts standard [MCP server-memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) JSONL files:
 
 ```jsonl
-{"type": "entity", "name": "Node Name", "entityType": "category"}
+{"type": "entity", "name": "Node Name", "entityType": "category", "observations": ["fact 1", "fact 2"]}
 {"type": "relation", "from": "Node Name", "to": "Target Name", "relationType": "connects_to"}
-{"type": "observation", "entityName": "Node Name", "contents": ["fact 1", "fact 2"]}
 ```
+
+Also supports JSON format: `{"entities": [...], "relations": [...]}`
 
 ## Requirements
 
@@ -51,7 +52,7 @@ The visualizer accepts standard MCP server-memory JSONL files:
 
 ## Agents & Automation
 
-- Memory MCP Client: Integrates with MCP server-memory for real-time graph updates
+- MCP integration planned for phase 3
 - GitHub Issues: [Issue #7](https://github.com/oshliaer/server-memory-editor/issues/7) (umbrella), #1-#6 (phase 1), #8-#9 (interactive filtering)
 
 ## Configuration

--- a/index.html
+++ b/index.html
@@ -197,6 +197,49 @@
 
         .actions { margin-top: 16px; }
 
+        /* Clickable info badges */
+        .detail-info .clickable {
+            color: #1a73e8;
+            cursor: pointer;
+            text-decoration: underline;
+        }
+
+        .detail-info .clickable:hover { color: #0d47a1; }
+
+        /* Duplicate versions list */
+        .versions-list { margin-top: 8px; display: none; }
+        .versions-list.open { display: block; }
+
+        .version-entry {
+            background: #fff3e0;
+            border-left: 3px solid #ff9800;
+            padding: 8px 12px;
+            margin-bottom: 6px;
+            border-radius: 4px;
+            font-size: 12px;
+        }
+
+        .version-entry .ver-type {
+            font-weight: 600;
+            color: #e65100;
+            margin-bottom: 4px;
+        }
+
+        .version-entry .ver-obs {
+            color: #555;
+            line-height: 1.4;
+        }
+
+        /* Clickable stats */
+        #stats .stat-filter {
+            color: #1a73e8;
+            cursor: pointer;
+            text-decoration: underline;
+        }
+
+        #stats .stat-filter:hover { color: #0d47a1; }
+        #stats .stat-filter.active { color: #d32f2f; font-weight: 600; }
+
         /* --- Legend (bottom-left) --- */
         #legend {
             position: absolute;
@@ -326,6 +369,7 @@
         <h2 id="detail-name"></h2>
         <span class="type-badge" id="detail-type"></span>
         <div class="detail-info" id="detail-info"></div>
+        <div class="versions-list" id="detail-versions"></div>
         <h3>Observations (<span id="detail-obs-count">0</span>)</h3>
         <div id="detail-observations"></div>
         <h3 id="detail-out-header">Outgoing</h3>
@@ -376,25 +420,31 @@
                 this._parseJSONL(trimmed, rawEntities, rawRelations);
             }
 
-            // 1. Process entities — merge duplicates
+            // 1. Process entities — merge duplicates, store original versions
             for (const e of rawEntities) {
                 if (!e.name) continue;
+                const version = {
+                    entityType: e.entityType || 'unknown',
+                    observations: [...(e.observations || [])]
+                };
                 const existing = this.entities.get(e.name);
                 if (existing) {
                     // Merge observations (exact string dedup)
                     const obsSet = new Set(existing.observations);
-                    for (const obs of (e.observations || [])) obsSet.add(obs);
+                    for (const obs of version.observations) obsSet.add(obs);
                     existing.observations = [...obsSet];
                     existing.entityType = e.entityType || existing.entityType;
                     existing.duplicateCount++;
+                    existing._versions.push(version);
                     this._stats.duplicates++;
                 } else {
                     this.entities.set(e.name, {
                         name: e.name,
                         entityType: e.entityType || 'unknown',
-                        observations: [...(e.observations || [])],
+                        observations: [...version.observations],
                         duplicateCount: 1,
-                        isGhost: false
+                        isGhost: false,
+                        _versions: [version]
                     });
                 }
             }
@@ -699,10 +749,49 @@
         badge.style.backgroundColor = entity.isGhost ? '#ccc' : colorScale(entity.entityType);
 
         // Info line
-        const infoParts = [];
-        if (entity.duplicateCount > 1) infoParts.push(`Встречается ${entity.duplicateCount} раз`);
-        if (entity.isGhost) infoParts.push('Ghost: entity не найдена в файле');
-        document.getElementById('detail-info').textContent = infoParts.join(' · ');
+        const infoEl = document.getElementById('detail-info');
+        const versionsEl = document.getElementById('detail-versions');
+        infoEl.innerHTML = '';
+        versionsEl.innerHTML = '';
+        versionsEl.classList.remove('open');
+
+        if (entity.duplicateCount > 1) {
+            const dupSpan = document.createElement('span');
+            dupSpan.className = 'clickable';
+            dupSpan.textContent = `Встречается ${entity.duplicateCount} раз — показать версии`;
+            dupSpan.addEventListener('click', () => {
+                versionsEl.classList.toggle('open');
+                dupSpan.textContent = versionsEl.classList.contains('open')
+                    ? `Встречается ${entity.duplicateCount} раз — скрыть версии`
+                    : `Встречается ${entity.duplicateCount} раз — показать версии`;
+            });
+            infoEl.appendChild(dupSpan);
+
+            // Populate versions
+            entity._versions.forEach((v, i) => {
+                const entry = document.createElement('div');
+                entry.className = 'version-entry';
+                const typeDiv = document.createElement('div');
+                typeDiv.className = 'ver-type';
+                typeDiv.textContent = `#${i + 1}: ${v.entityType}`;
+                entry.appendChild(typeDiv);
+                if (v.observations.length) {
+                    const obsDiv = document.createElement('div');
+                    obsDiv.className = 'ver-obs';
+                    obsDiv.textContent = v.observations.join(' | ');
+                    entry.appendChild(obsDiv);
+                }
+                versionsEl.appendChild(entry);
+            });
+        }
+
+        if (entity.isGhost) {
+            if (infoEl.childNodes.length) infoEl.appendChild(document.createTextNode(' · '));
+            const ghostSpan = document.createElement('span');
+            ghostSpan.style.color = '#888';
+            ghostSpan.textContent = 'Ghost: entity не найдена в файле';
+            infoEl.appendChild(ghostSpan);
+        }
 
         // Observations
         document.getElementById('detail-obs-count').textContent = entity.observations.length;
@@ -833,16 +922,65 @@
     }
 
     // Stats
+    let activeFilter = null; // 'ghost' | 'dup' | null
+
     function updateStats() {
         const s = DataModel.getStats();
-        const parts = [`${s.entities} entities`];
-        const sub = [];
-        if (s.duplicates > 0) sub.push(`${s.duplicates} dup`);
-        if (s.ghosts > 0) sub.push(`${s.ghosts} ghost`);
-        if (sub.length) parts[0] += ` (${sub.join(', ')})`;
-        parts.push(`${s.relations} relations`);
-        if (s.skipped > 0) parts.push(`${s.skipped} skipped`);
-        document.getElementById('stats').textContent = parts.join(' \u00b7 ');
+        const el = document.getElementById('stats');
+        el.innerHTML = '';
+
+        el.appendChild(document.createTextNode(`${s.entities} entities`));
+
+        if (s.duplicates > 0 || s.ghosts > 0) {
+            el.appendChild(document.createTextNode(' ('));
+            if (s.duplicates > 0) {
+                const dupLink = document.createElement('span');
+                dupLink.className = 'stat-filter' + (activeFilter === 'dup' ? ' active' : '');
+                dupLink.textContent = `${s.duplicates} dup`;
+                dupLink.addEventListener('click', () => toggleFilter('dup'));
+                el.appendChild(dupLink);
+            }
+            if (s.duplicates > 0 && s.ghosts > 0) {
+                el.appendChild(document.createTextNode(', '));
+            }
+            if (s.ghosts > 0) {
+                const ghostLink = document.createElement('span');
+                ghostLink.className = 'stat-filter' + (activeFilter === 'ghost' ? ' active' : '');
+                ghostLink.textContent = `${s.ghosts} ghost`;
+                ghostLink.addEventListener('click', () => toggleFilter('ghost'));
+                el.appendChild(ghostLink);
+            }
+            el.appendChild(document.createTextNode(')'));
+        }
+
+        el.appendChild(document.createTextNode(` \u00b7 ${s.relations} relations`));
+        if (s.skipped > 0) el.appendChild(document.createTextNode(` \u00b7 ${s.skipped} skipped`));
+    }
+
+    function toggleFilter(type) {
+        if (activeFilter === type) {
+            // Deactivate — show all
+            activeFilter = null;
+            nodeSelection.classed('dimmed', false);
+            linkSelection.classed('dimmed', false);
+            labelSelection.classed('dimmed', false);
+        } else {
+            activeFilter = type;
+            const matchFn = type === 'ghost'
+                ? d => d.isGhost
+                : d => d.duplicateCount > 1;
+            const matchNames = new Set();
+            nodeSelection.each(d => { if (matchFn(d)) matchNames.add(d.name); });
+
+            nodeSelection.classed('dimmed', d => !matchNames.has(d.name));
+            labelSelection.classed('dimmed', d => !matchNames.has(d.name));
+            linkSelection.classed('dimmed', d => {
+                const sName = typeof d.source === 'object' ? d.source.name : d.source;
+                const tName = typeof d.target === 'object' ? d.target.name : d.target;
+                return !matchNames.has(sName) && !matchNames.has(tName);
+            });
+        }
+        updateStats();
     }
 
     // Export

--- a/index.html
+++ b/index.html
@@ -477,7 +477,8 @@
                             entityType: 'unknown',
                             observations: [],
                             duplicateCount: 0,
-                            isGhost: true
+                            isGhost: true,
+                            _versions: []
                         });
                         this._stats.ghosts++;
                     }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,942 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Memory JSONL Visualizer</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #f5f5f5;
+            overflow: hidden;
+            height: 100vh;
+        }
+
+        svg {
+            width: 100%;
+            height: 100vh;
+            cursor: move;
+        }
+
+        /* --- Controls panel (top-left) --- */
+        #controls {
+            position: absolute;
+            top: 16px;
+            left: 16px;
+            background: white;
+            padding: 16px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+            z-index: 100;
+            width: 280px;
+            font-size: 14px;
+        }
+
+        #controls h3 {
+            margin-bottom: 12px;
+            color: #333;
+            font-size: 16px;
+        }
+
+        #search {
+            width: 100%;
+            padding: 8px 10px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            font-size: 14px;
+            margin-bottom: 10px;
+        }
+
+        #search:focus { outline: none; border-color: #667eea; }
+
+        .control-buttons {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 10px;
+        }
+
+        .control-btn {
+            flex: 1;
+            padding: 6px;
+            border: 1px solid #ddd;
+            background: white;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 12px;
+            transition: background 0.15s;
+        }
+
+        .control-btn:hover { background: #f0f0f0; }
+
+        #stats {
+            font-size: 13px;
+            color: #666;
+            margin-bottom: 10px;
+        }
+
+        .upload-area {
+            border: 2px dashed #ccc;
+            border-radius: 5px;
+            padding: 14px;
+            text-align: center;
+            cursor: pointer;
+            transition: border-color 0.2s, background 0.2s;
+            font-size: 13px;
+            color: #666;
+        }
+
+        .upload-area:hover { border-color: #667eea; background: #f8f9ff; }
+        .upload-area.dragover { border-color: #667eea; background: #f0f1ff; }
+
+        #file-input { display: none; }
+
+        /* --- Details panel (top-right) --- */
+        #details {
+            position: absolute;
+            top: 16px;
+            right: 16px;
+            width: 360px;
+            max-height: calc(100vh - 32px);
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+            overflow-y: auto;
+            display: none;
+            z-index: 100;
+        }
+
+        #details .close-btn {
+            float: right;
+            cursor: pointer;
+            font-size: 24px;
+            color: #999;
+            line-height: 20px;
+            border: none;
+            background: none;
+        }
+
+        #details .close-btn:hover { color: #333; }
+
+        #details h2 {
+            margin-top: 0;
+            color: #333;
+            font-size: 18px;
+            padding-right: 30px;
+            word-break: break-word;
+        }
+
+        .type-badge {
+            display: inline-block;
+            padding: 2px 10px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+            color: white;
+            margin-bottom: 12px;
+        }
+
+        .detail-info {
+            font-size: 13px;
+            color: #888;
+            margin-bottom: 12px;
+        }
+
+        #details h3 {
+            font-size: 14px;
+            color: #555;
+            margin: 14px 0 8px;
+        }
+
+        .observation {
+            background: #f8f9fa;
+            padding: 8px 12px;
+            margin-bottom: 6px;
+            border-radius: 4px;
+            font-size: 13px;
+            line-height: 1.5;
+            border-left: 3px solid #667eea;
+            word-break: break-word;
+        }
+
+        .relation-item {
+            background: #e8f0fe;
+            padding: 8px 12px;
+            margin-bottom: 6px;
+            border-radius: 4px;
+            font-size: 13px;
+        }
+
+        .relation-item .rel-top {
+            display: flex;
+            align-items: baseline;
+            gap: 6px;
+        }
+
+        .relation-item .rel-arrow { color: #667eea; font-weight: bold; }
+
+        .relation-item .rel-name {
+            color: #1a73e8;
+            cursor: pointer;
+            text-decoration: underline;
+            word-break: break-word;
+        }
+
+        .relation-item .rel-type {
+            color: #888;
+            font-size: 12px;
+            font-style: italic;
+            margin-top: 2px;
+            padding-left: 18px;
+        }
+
+        .relation-item .rel-name:hover { color: #0d47a1; }
+
+        .actions { margin-top: 16px; }
+
+        /* --- Legend (bottom-left) --- */
+        #legend {
+            position: absolute;
+            bottom: 16px;
+            left: 16px;
+            background: white;
+            padding: 12px 16px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+            max-height: 250px;
+            overflow-y: auto;
+            z-index: 100;
+            display: none;
+        }
+
+        #legend strong { font-size: 13px; color: #333; }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            margin-top: 6px;
+            font-size: 12px;
+            color: #555;
+        }
+
+        .legend-color {
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            margin-right: 8px;
+            flex-shrink: 0;
+            border: 1px solid rgba(0,0,0,0.1);
+        }
+
+        /* --- Empty state --- */
+        #empty-state {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            text-align: center;
+            color: #999;
+            z-index: 50;
+            pointer-events: none;
+        }
+
+        #empty-state .icon { font-size: 48px; margin-bottom: 16px; }
+        #empty-state p { font-size: 16px; margin-bottom: 8px; }
+        #empty-state .hint { font-size: 13px; }
+
+        /* --- Dropzone overlay --- */
+        #dropzone-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(102, 126, 234, 0.15);
+            border: 4px dashed #667eea;
+            z-index: 9999;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            font-size: 24px;
+            color: #667eea;
+            font-weight: bold;
+        }
+
+        /* --- Graph styles --- */
+        .node {
+            stroke: white;
+            stroke-width: 2px;
+            cursor: pointer;
+        }
+
+        .node:hover { stroke: #333; stroke-width: 3px; }
+        .node.selected { stroke: #ff4444; stroke-width: 4px; }
+        .node.ghost { stroke-dasharray: 4,2; }
+        .node.duplicate { stroke-width: 4px; }
+
+        .link {
+            stroke: #999;
+            stroke-opacity: 0.5;
+            fill: none;
+        }
+
+        .node-label {
+            font-size: 11px;
+            pointer-events: none;
+            text-anchor: middle;
+            fill: #333;
+            paint-order: stroke;
+            stroke: white;
+            stroke-width: 3px;
+            stroke-linecap: round;
+            stroke-linejoin: round;
+        }
+
+        .dimmed { opacity: 0.1 !important; }
+    </style>
+</head>
+<body>
+    <div id="empty-state">
+        <div class="icon">&#128202;</div>
+        <p>Перетащите .jsonl файл сюда</p>
+        <p class="hint">или нажмите кнопку загрузки в панели слева</p>
+    </div>
+
+    <div id="dropzone-overlay">Отпустите файл для загрузки</div>
+
+    <div id="controls">
+        <h3>Memory Visualizer</h3>
+        <input type="text" id="search" placeholder="Поиск..." disabled />
+        <div class="control-buttons">
+            <button class="control-btn" id="btn-reset">Сброс</button>
+            <button class="control-btn" id="btn-zoom-in">+</button>
+            <button class="control-btn" id="btn-zoom-out">&minus;</button>
+            <button class="control-btn" id="btn-export" disabled>Export</button>
+        </div>
+        <div id="stats"></div>
+        <div class="upload-area" id="upload-area">
+            <div style="font-size:1.5em;margin-bottom:4px;">&#128193;</div>
+            <div>Загрузить .jsonl / .json</div>
+        </div>
+        <input type="file" id="file-input" accept=".jsonl,.json" />
+    </div>
+
+    <div id="details">
+        <button class="close-btn" id="close-details">&times;</button>
+        <h2 id="detail-name"></h2>
+        <span class="type-badge" id="detail-type"></span>
+        <div class="detail-info" id="detail-info"></div>
+        <h3>Observations (<span id="detail-obs-count">0</span>)</h3>
+        <div id="detail-observations"></div>
+        <h3 id="detail-out-header">Outgoing</h3>
+        <div id="detail-outgoing"></div>
+        <h3 id="detail-in-header">Incoming</h3>
+        <div id="detail-incoming"></div>
+        <div class="actions" id="detail-actions"></div>
+    </div>
+
+    <div id="legend">
+        <strong>Entity Types</strong>
+        <div id="legend-items"></div>
+    </div>
+
+    <script>
+    // ========================================================================
+    // DataModel
+    // ========================================================================
+    const DataModel = {
+        entities: new Map(),
+        relations: [],
+        _stats: { duplicates: 0, ghosts: 0, skipped: 0 },
+
+        clear() {
+            this.entities.clear();
+            this.relations = [];
+            this._stats = { duplicates: 0, ghosts: 0, skipped: 0 };
+        },
+
+        loadFromText(text) {
+            this.clear();
+            let rawEntities = [];
+            let rawRelations = [];
+
+            // Detect format: JSON vs JSONL
+            const trimmed = text.trim();
+            try {
+                const json = JSON.parse(trimmed);
+                if (json && typeof json === 'object' && (Array.isArray(json.entities) || Array.isArray(json.relations))) {
+                    rawEntities = json.entities || [];
+                    rawRelations = json.relations || [];
+                } else {
+                    // Single JSON object — treat as JSONL with one line
+                    this._parseJSONL(trimmed, rawEntities, rawRelations);
+                }
+            } catch {
+                // Not valid JSON — parse as JSONL
+                this._parseJSONL(trimmed, rawEntities, rawRelations);
+            }
+
+            // 1. Process entities — merge duplicates
+            for (const e of rawEntities) {
+                if (!e.name) continue;
+                const existing = this.entities.get(e.name);
+                if (existing) {
+                    // Merge observations (exact string dedup)
+                    const obsSet = new Set(existing.observations);
+                    for (const obs of (e.observations || [])) obsSet.add(obs);
+                    existing.observations = [...obsSet];
+                    existing.entityType = e.entityType || existing.entityType;
+                    existing.duplicateCount++;
+                    this._stats.duplicates++;
+                } else {
+                    this.entities.set(e.name, {
+                        name: e.name,
+                        entityType: e.entityType || 'unknown',
+                        observations: [...(e.observations || [])],
+                        duplicateCount: 1,
+                        isGhost: false
+                    });
+                }
+            }
+
+            // 2. Process relations — dedup by from+to+relationType
+            const relSet = new Set();
+            for (const r of rawRelations) {
+                if (!r.from || !r.to) continue;
+                const key = `${r.from}\0${r.to}\0${r.relationType || ''}`;
+                if (relSet.has(key)) continue;
+                relSet.add(key);
+                this.relations.push({
+                    from: r.from,
+                    to: r.to,
+                    relationType: r.relationType || ''
+                });
+            }
+
+            // 3. Create ghost nodes for dangling relations
+            for (const r of this.relations) {
+                for (const name of [r.from, r.to]) {
+                    if (!this.entities.has(name)) {
+                        this.entities.set(name, {
+                            name,
+                            entityType: 'unknown',
+                            observations: [],
+                            duplicateCount: 0,
+                            isGhost: true
+                        });
+                        this._stats.ghosts++;
+                    }
+                }
+            }
+
+            console.log(`Loaded: ${this.entities.size} entities (${this._stats.duplicates} dup, ${this._stats.ghosts} ghost), ${this.relations.length} relations, ${this._stats.skipped} skipped`);
+        },
+
+        _parseJSONL(text, entities, relations) {
+            const lines = text.split('\n');
+            for (const line of lines) {
+                const t = line.trim();
+                if (!t) continue;
+                try {
+                    const obj = JSON.parse(t);
+                    if (obj.type === 'entity') entities.push(obj);
+                    else if (obj.type === 'relation') relations.push(obj);
+                } catch {
+                    this._stats.skipped++;
+                    console.warn('Skipped invalid line:', t.substring(0, 80));
+                }
+            }
+        },
+
+        toJSONL() {
+            const lines = [];
+            for (const [, e] of this.entities) {
+                if (e.isGhost) continue;
+                lines.push(JSON.stringify({
+                    type: 'entity',
+                    name: e.name,
+                    entityType: e.entityType,
+                    observations: e.observations
+                }));
+            }
+            for (const r of this.relations) {
+                lines.push(JSON.stringify({
+                    type: 'relation',
+                    from: r.from,
+                    to: r.to,
+                    relationType: r.relationType
+                }));
+            }
+            return lines.join('\n') + '\n';
+        },
+
+        getStats() {
+            return {
+                entities: this.entities.size,
+                relations: this.relations.length,
+                duplicates: this._stats.duplicates,
+                ghosts: this._stats.ghosts,
+                skipped: this._stats.skipped
+            };
+        }
+    };
+
+    // ========================================================================
+    // Renderer
+    // ========================================================================
+    let svg, g, zoomBehavior, simulation;
+    let nodeSelection, linkSelection, labelSelection;
+    let colorScale;
+    let selectedNodeName = null;
+
+    const width = () => window.innerWidth;
+    const height = () => window.innerHeight;
+
+    function nodeRadius(d) {
+        return Math.max(8, Math.min(28, 5 + d.observations.length * 2));
+    }
+
+    function initSVG() {
+        svg = d3.select('body')
+            .insert('svg', '#empty-state')
+            .attr('width', width())
+            .attr('height', height());
+
+        g = svg.append('g');
+
+        // Arrow marker
+        svg.append('defs').append('marker')
+            .attr('id', 'arrowhead')
+            .attr('viewBox', '0 -5 10 10')
+            .attr('refX', 2)
+            .attr('refY', 0)
+            .attr('orient', 'auto')
+            .attr('markerWidth', 8)
+            .attr('markerHeight', 8)
+            .append('path')
+            .attr('d', 'M0,-4L8,0L0,4')
+            .attr('fill', '#999');
+
+        // Zoom
+        zoomBehavior = d3.zoom()
+            .scaleExtent([0.1, 10])
+            .on('zoom', (event) => g.attr('transform', event.transform));
+
+        svg.call(zoomBehavior);
+
+        // Click on background -> deselect
+        svg.on('click', (event) => {
+            if (event.target.tagName === 'svg') clearSelection();
+        });
+    }
+
+    function render(model) {
+        // Prepare data arrays
+        const nodes = [];
+        for (const [, e] of model.entities) {
+            nodes.push({ ...e });
+        }
+
+        const links = model.relations.map(r => ({
+            source: r.from,
+            target: r.to,
+            relationType: r.relationType
+        }));
+
+        // Color scale
+        const types = [...new Set(nodes.map(n => n.entityType))].sort();
+        colorScale = d3.scaleOrdinal(d3.schemeTableau10).domain(types);
+
+        // Clear
+        g.selectAll('*').remove();
+
+        // Links
+        const linkGroup = g.append('g').attr('id', 'links-group');
+        linkSelection = linkGroup.selectAll('line')
+            .data(links)
+            .enter().append('line')
+            .attr('class', 'link')
+            .attr('stroke-width', 1.5)
+            .attr('marker-end', 'url(#arrowhead)');
+
+        // Nodes
+        const nodeGroup = g.append('g').attr('id', 'nodes-group');
+        nodeSelection = nodeGroup.selectAll('circle')
+            .data(nodes, d => d.name)
+            .enter().append('circle')
+            .attr('class', d => {
+                let cls = 'node';
+                if (d.isGhost) cls += ' ghost';
+                if (d.duplicateCount > 1) cls += ' duplicate';
+                return cls;
+            })
+            .attr('r', d => nodeRadius(d))
+            .attr('fill', d => d.isGhost ? '#ccc' : colorScale(d.entityType))
+            .on('click', (event, d) => {
+                event.stopPropagation();
+                selectNode(d.name);
+            })
+            .call(d3.drag()
+                .on('start', dragStarted)
+                .on('drag', dragged)
+                .on('end', dragEnded));
+
+        nodeSelection.append('title')
+            .text(d => `${d.name}\n${d.entityType}\n${d.observations.length} obs`);
+
+        // Labels
+        const labelGroup = g.append('g').attr('id', 'labels-group');
+        labelSelection = labelGroup.selectAll('text')
+            .data(nodes, d => d.name)
+            .enter().append('text')
+            .attr('class', 'node-label')
+            .text(d => d.name.length > 25 ? d.name.substring(0, 23) + '...' : d.name)
+            .attr('dy', d => -nodeRadius(d) - 4);
+
+        // Simulation
+        if (simulation) simulation.stop();
+        simulation = d3.forceSimulation(nodes)
+            .force('link', d3.forceLink(links).id(d => d.name).distance(100))
+            .force('charge', d3.forceManyBody().strength(-500))
+            .force('center', d3.forceCenter(width() / 2, height() / 2))
+            .force('collision', d3.forceCollide(d => nodeRadius(d) + 5))
+            .on('tick', ticked);
+
+        // Fit-to-view only once after initial layout
+        let fitted = false;
+        simulation.on('end', () => {
+            if (!fitted) {
+                fitted = true;
+                fitToView();
+            }
+        });
+
+        // Show UI
+        document.getElementById('empty-state').style.display = 'none';
+        document.getElementById('legend').style.display = 'block';
+        document.getElementById('search').disabled = false;
+        document.getElementById('btn-export').disabled = false;
+
+        updateLegend(types);
+        updateStats();
+    }
+
+    function ticked() {
+        linkSelection.each(function(d) {
+            const dx = d.target.x - d.source.x;
+            const dy = d.target.y - d.source.y;
+            const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+            const tR = nodeRadius(d.target);
+            const sR = nodeRadius(d.source);
+            // Shorten line to node boundaries
+            d3.select(this)
+                .attr('x1', d.source.x + dx / dist * sR)
+                .attr('y1', d.source.y + dy / dist * sR)
+                .attr('x2', d.target.x - dx / dist * (tR + 8))
+                .attr('y2', d.target.y - dy / dist * (tR + 8));
+        });
+
+        nodeSelection
+            .attr('cx', d => d.x)
+            .attr('cy', d => d.y);
+
+        labelSelection
+            .attr('x', d => d.x)
+            .attr('y', d => d.y);
+    }
+
+    function fitToView() {
+        const bbox = g.node().getBBox();
+        if (bbox.width === 0 || bbox.height === 0) return;
+        const pad = 60;
+        const w = width();
+        const h = height();
+        const scale = 0.9 * Math.min((w - pad * 2) / bbox.width, (h - pad * 2) / bbox.height);
+        const tx = w / 2 - scale * (bbox.x + bbox.width / 2);
+        const ty = h / 2 - scale * (bbox.y + bbox.height / 2);
+        svg.transition().duration(500)
+            .call(zoomBehavior.transform, d3.zoomIdentity.translate(tx, ty).scale(scale));
+    }
+
+    // Drag
+    function dragStarted(event, d) {
+        if (!event.active) simulation.alphaTarget(0.3).restart();
+        d.fx = d.x;
+        d.fy = d.y;
+    }
+
+    function dragged(event, d) {
+        d.fx = event.x;
+        d.fy = event.y;
+    }
+
+    function dragEnded(event, d) {
+        if (!event.active) simulation.alphaTarget(0);
+        d.fx = null;
+        d.fy = null;
+    }
+
+    // ========================================================================
+    // UI
+    // ========================================================================
+
+    function selectNode(name) {
+        selectedNodeName = name;
+        const entity = DataModel.entities.get(name);
+        if (!entity) return;
+
+        // Highlight
+        highlightConnections(name);
+
+        // Detail panel
+        const panel = document.getElementById('details');
+        panel.style.display = 'block';
+
+        document.getElementById('detail-name').textContent = entity.name;
+
+        const badge = document.getElementById('detail-type');
+        badge.textContent = entity.entityType;
+        badge.style.backgroundColor = entity.isGhost ? '#ccc' : colorScale(entity.entityType);
+
+        // Info line
+        const infoParts = [];
+        if (entity.duplicateCount > 1) infoParts.push(`Встречается ${entity.duplicateCount} раз`);
+        if (entity.isGhost) infoParts.push('Ghost: entity не найдена в файле');
+        document.getElementById('detail-info').textContent = infoParts.join(' · ');
+
+        // Observations
+        document.getElementById('detail-obs-count').textContent = entity.observations.length;
+        const obsEl = document.getElementById('detail-observations');
+        obsEl.innerHTML = '';
+        for (const obs of entity.observations) {
+            const div = document.createElement('div');
+            div.className = 'observation';
+            div.textContent = obs;
+            obsEl.appendChild(div);
+        }
+
+        // Outgoing relations
+        const outgoing = DataModel.relations.filter(r => r.from === name);
+        const outEl = document.getElementById('detail-outgoing');
+        const outHeader = document.getElementById('detail-out-header');
+        outEl.innerHTML = '';
+        outHeader.textContent = `Исходящие (${outgoing.length})`;
+        for (const r of outgoing) {
+            outEl.appendChild(createRelationItem('→', r.relationType, r.to));
+        }
+
+        // Incoming relations
+        const incoming = DataModel.relations.filter(r => r.to === name);
+        const inEl = document.getElementById('detail-incoming');
+        const inHeader = document.getElementById('detail-in-header');
+        inEl.innerHTML = '';
+        inHeader.textContent = `Входящие (${incoming.length})`;
+        for (const r of incoming) {
+            inEl.appendChild(createRelationItem('←', r.relationType, r.from));
+        }
+    }
+
+    function createRelationItem(arrow, type, targetName) {
+        const div = document.createElement('div');
+        div.className = 'relation-item';
+        // Line 1: arrow + entity name
+        const top = document.createElement('div');
+        top.className = 'rel-top';
+        top.innerHTML = `<span class="rel-arrow">${arrow}</span>`;
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'rel-name';
+        nameSpan.textContent = targetName;
+        nameSpan.addEventListener('click', () => selectNode(targetName));
+        top.appendChild(nameSpan);
+        div.appendChild(top);
+        // Line 2: relation type
+        if (type) {
+            const typeDiv = document.createElement('div');
+            typeDiv.className = 'rel-type';
+            typeDiv.textContent = type;
+            div.appendChild(typeDiv);
+        }
+        return div;
+    }
+
+    function highlightConnections(name) {
+        const connected = new Set([name]);
+        for (const r of DataModel.relations) {
+            if (r.from === name) connected.add(r.to);
+            if (r.to === name) connected.add(r.from);
+        }
+
+        nodeSelection
+            .classed('dimmed', d => !connected.has(d.name))
+            .classed('selected', d => d.name === name);
+
+        linkSelection.classed('dimmed', d => {
+            const sName = typeof d.source === 'object' ? d.source.name : d.source;
+            const tName = typeof d.target === 'object' ? d.target.name : d.target;
+            return sName !== name && tName !== name;
+        });
+
+        labelSelection.classed('dimmed', d => !connected.has(d.name));
+    }
+
+    function clearSelection() {
+        selectedNodeName = null;
+        document.getElementById('details').style.display = 'none';
+        nodeSelection && nodeSelection.classed('dimmed', false).classed('selected', false);
+        linkSelection && linkSelection.classed('dimmed', false);
+        labelSelection && labelSelection.classed('dimmed', false);
+    }
+
+    // Search
+    function setupSearch() {
+        document.getElementById('search').addEventListener('input', (e) => {
+            const q = e.target.value.toLowerCase().trim();
+            if (!q) {
+                nodeSelection.classed('dimmed', false);
+                linkSelection.classed('dimmed', false);
+                labelSelection.classed('dimmed', false);
+                return;
+            }
+
+            const matches = new Set();
+            for (const [, ent] of DataModel.entities) {
+                const haystack = [ent.name, ent.entityType, ...ent.observations].join(' ').toLowerCase();
+                if (haystack.includes(q)) matches.add(ent.name);
+            }
+
+            nodeSelection.classed('dimmed', d => !matches.has(d.name));
+            labelSelection.classed('dimmed', d => !matches.has(d.name));
+            linkSelection.classed('dimmed', d => {
+                const sName = typeof d.source === 'object' ? d.source.name : d.source;
+                const tName = typeof d.target === 'object' ? d.target.name : d.target;
+                return !matches.has(sName) && !matches.has(tName);
+            });
+        });
+    }
+
+    // Legend
+    function updateLegend(types) {
+        const container = document.getElementById('legend-items');
+        container.innerHTML = '';
+        for (const t of types) {
+            const item = document.createElement('div');
+            item.className = 'legend-item';
+            const circle = document.createElement('div');
+            circle.className = 'legend-color';
+            circle.style.backgroundColor = colorScale(t);
+            const label = document.createElement('span');
+            label.textContent = t;
+            item.appendChild(circle);
+            item.appendChild(label);
+            container.appendChild(item);
+        }
+    }
+
+    // Stats
+    function updateStats() {
+        const s = DataModel.getStats();
+        const parts = [`${s.entities} entities`];
+        const sub = [];
+        if (s.duplicates > 0) sub.push(`${s.duplicates} dup`);
+        if (s.ghosts > 0) sub.push(`${s.ghosts} ghost`);
+        if (sub.length) parts[0] += ` (${sub.join(', ')})`;
+        parts.push(`${s.relations} relations`);
+        if (s.skipped > 0) parts.push(`${s.skipped} skipped`);
+        document.getElementById('stats').textContent = parts.join(' \u00b7 ');
+    }
+
+    // Export
+    function exportJSONL() {
+        const text = DataModel.toJSONL();
+        const blob = new Blob([text], { type: 'application/x-jsonlines' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'memory.jsonl';
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    // File loading
+    function handleFile(file) {
+        if (!file) return;
+        if (!file.name.endsWith('.jsonl') && !file.name.endsWith('.json')) {
+            alert('Поддерживаются только .jsonl и .json файлы');
+            return;
+        }
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            DataModel.loadFromText(e.target.result);
+            if (DataModel.entities.size === 0) {
+                alert('Файл не содержит данных или имеет неверный формат');
+                return;
+            }
+            render(DataModel);
+        };
+        reader.readAsText(file);
+    }
+
+    // ========================================================================
+    // Init
+    // ========================================================================
+    document.addEventListener('DOMContentLoaded', () => {
+        initSVG();
+        setupSearch();
+
+        // File input
+        const fileInput = document.getElementById('file-input');
+        document.getElementById('upload-area').addEventListener('click', () => fileInput.click());
+        fileInput.addEventListener('change', (e) => handleFile(e.target.files[0]));
+
+        // Buttons
+        document.getElementById('btn-reset').addEventListener('click', () => {
+            svg.transition().duration(500).call(zoomBehavior.transform, d3.zoomIdentity);
+        });
+        document.getElementById('btn-zoom-in').addEventListener('click', () => {
+            svg.transition().duration(200).call(zoomBehavior.scaleBy, 1.4);
+        });
+        document.getElementById('btn-zoom-out').addEventListener('click', () => {
+            svg.transition().duration(200).call(zoomBehavior.scaleBy, 0.7);
+        });
+        document.getElementById('btn-export').addEventListener('click', exportJSONL);
+        document.getElementById('close-details').addEventListener('click', clearSelection);
+
+        // Escape
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') clearSelection();
+        });
+
+        // Document-level drag and drop
+        const overlay = document.getElementById('dropzone-overlay');
+        let dragCounter = 0;
+
+        document.addEventListener('dragenter', (e) => {
+            e.preventDefault();
+            dragCounter++;
+            overlay.style.display = 'flex';
+        });
+
+        document.addEventListener('dragleave', (e) => {
+            e.preventDefault();
+            dragCounter--;
+            if (dragCounter <= 0) {
+                dragCounter = 0;
+                overlay.style.display = 'none';
+            }
+        });
+
+        document.addEventListener('dragover', (e) => {
+            e.preventDefault();
+        });
+
+        document.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dragCounter = 0;
+            overlay.style.display = 'none';
+            const file = e.dataTransfer.files[0];
+            if (file) handleFile(file);
+        });
+    });
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
             stroke-linejoin: round;
         }
 
-        .dimmed { opacity: 0.1 !important; }
+        .dimmed { opacity: 0.15 !important; }
     </style>
 </head>
 <body>
@@ -416,9 +416,10 @@
                 } else if (json && typeof json === 'object' && (Array.isArray(json.entities) || Array.isArray(json.relations))) {
                     rawEntities = json.entities || [];
                     rawRelations = json.relations || [];
-                } else {
-                    // Single JSON object — treat as JSONL with one line
-                    this._parseJSONL(trimmed, rawEntities, rawRelations);
+                } else if (json && typeof json === 'object' && json.type) {
+                    // Single entity/relation object
+                    if (json.type === 'entity') rawEntities.push(json);
+                    else if (json.type === 'relation') rawRelations.push(json);
                 }
             } catch {
                 // Not valid JSON — parse as JSONL
@@ -865,7 +866,7 @@
         linkSelection.classed('dimmed', d => {
             const sName = typeof d.source === 'object' ? d.source.name : d.source;
             const tName = typeof d.target === 'object' ? d.target.name : d.target;
-            return !nameSet.has(sName) && !nameSet.has(tName);
+            return !nameSet.has(sName) || !nameSet.has(tName);
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
             <button class="control-btn" id="btn-export" disabled>Export</button>
         </div>
         <div id="stats"></div>
-        <div class="upload-area" id="upload-area">
+        <div class="upload-area" id="upload-area" role="button" tabindex="0">
             <div style="font-size:1.5em;margin-bottom:4px;">&#128193;</div>
             <div>Загрузить .jsonl / .json</div>
         </div>
@@ -408,7 +408,12 @@
             const trimmed = text.trim();
             try {
                 const json = JSON.parse(trimmed);
-                if (json && typeof json === 'object' && (Array.isArray(json.entities) || Array.isArray(json.relations))) {
+                if (Array.isArray(json)) {
+                    for (const obj of json) {
+                        if (obj.type === 'entity') rawEntities.push(obj);
+                        else if (obj.type === 'relation') rawRelations.push(obj);
+                    }
+                } else if (json && typeof json === 'object' && (Array.isArray(json.entities) || Array.isArray(json.relations))) {
                     rawEntities = json.entities || [];
                     rawRelations = json.relations || [];
                 } else {
@@ -510,6 +515,9 @@
                 }));
             }
             for (const r of this.relations) {
+                const from = this.entities.get(r.from);
+                const to = this.entities.get(r.to);
+                if (!from || !to || from.isGhost || to.isGhost) continue;
                 lines.push(JSON.stringify({
                     type: 'relation',
                     from: r.from,
@@ -848,58 +856,53 @@
         return div;
     }
 
+    // Shared dimming helpers
+    function dimByNameSet(nameSet) {
+        if (!nodeSelection) return;
+        nodeSelection.classed('dimmed', d => !nameSet.has(d.name));
+        labelSelection.classed('dimmed', d => !nameSet.has(d.name));
+        linkSelection.classed('dimmed', d => {
+            const sName = typeof d.source === 'object' ? d.source.name : d.source;
+            const tName = typeof d.target === 'object' ? d.target.name : d.target;
+            return !nameSet.has(sName) && !nameSet.has(tName);
+        });
+    }
+
+    function clearDimming() {
+        if (!nodeSelection) return;
+        nodeSelection.classed('dimmed', false).classed('selected', false);
+        linkSelection.classed('dimmed', false);
+        labelSelection.classed('dimmed', false);
+    }
+
     function highlightConnections(name) {
         const connected = new Set([name]);
         for (const r of DataModel.relations) {
             if (r.from === name) connected.add(r.to);
             if (r.to === name) connected.add(r.from);
         }
-
-        nodeSelection
-            .classed('dimmed', d => !connected.has(d.name))
-            .classed('selected', d => d.name === name);
-
-        linkSelection.classed('dimmed', d => {
-            const sName = typeof d.source === 'object' ? d.source.name : d.source;
-            const tName = typeof d.target === 'object' ? d.target.name : d.target;
-            return sName !== name && tName !== name;
-        });
-
-        labelSelection.classed('dimmed', d => !connected.has(d.name));
+        dimByNameSet(connected);
+        nodeSelection.classed('selected', d => d.name === name);
     }
 
     function clearSelection() {
         selectedNodeName = null;
         document.getElementById('details').style.display = 'none';
-        nodeSelection && nodeSelection.classed('dimmed', false).classed('selected', false);
-        linkSelection && linkSelection.classed('dimmed', false);
-        labelSelection && labelSelection.classed('dimmed', false);
+        clearDimming();
     }
 
     // Search
     function setupSearch() {
         document.getElementById('search').addEventListener('input', (e) => {
             const q = e.target.value.toLowerCase().trim();
-            if (!q) {
-                nodeSelection.classed('dimmed', false);
-                linkSelection.classed('dimmed', false);
-                labelSelection.classed('dimmed', false);
-                return;
-            }
+            if (!q) { clearDimming(); return; }
 
             const matches = new Set();
             for (const [, ent] of DataModel.entities) {
                 const haystack = [ent.name, ent.entityType, ...ent.observations].join(' ').toLowerCase();
                 if (haystack.includes(q)) matches.add(ent.name);
             }
-
-            nodeSelection.classed('dimmed', d => !matches.has(d.name));
-            labelSelection.classed('dimmed', d => !matches.has(d.name));
-            linkSelection.classed('dimmed', d => {
-                const sName = typeof d.source === 'object' ? d.source.name : d.source;
-                const tName = typeof d.target === 'object' ? d.target.name : d.target;
-                return !matches.has(sName) && !matches.has(tName);
-            });
+            dimByNameSet(matches);
         });
     }
 
@@ -959,11 +962,8 @@
 
     function toggleFilter(type) {
         if (activeFilter === type) {
-            // Deactivate — show all
             activeFilter = null;
-            nodeSelection.classed('dimmed', false);
-            linkSelection.classed('dimmed', false);
-            labelSelection.classed('dimmed', false);
+            clearDimming();
         } else {
             activeFilter = type;
             const matchFn = type === 'ghost'
@@ -971,14 +971,7 @@
                 : d => d.duplicateCount > 1;
             const matchNames = new Set();
             nodeSelection.each(d => { if (matchFn(d)) matchNames.add(d.name); });
-
-            nodeSelection.classed('dimmed', d => !matchNames.has(d.name));
-            labelSelection.classed('dimmed', d => !matchNames.has(d.name));
-            linkSelection.classed('dimmed', d => {
-                const sName = typeof d.source === 'object' ? d.source.name : d.source;
-                const tName = typeof d.target === 'object' ? d.target.name : d.target;
-                return !matchNames.has(sName) && !matchNames.has(tName);
-            });
+            dimByNameSet(matchNames);
         }
         updateStats();
     }
@@ -998,14 +991,22 @@
     // File loading
     function handleFile(file) {
         if (!file) return;
-        if (!file.name.endsWith('.jsonl') && !file.name.endsWith('.json')) {
+        const fileName = file.name.toLowerCase();
+        if (!fileName.endsWith('.jsonl') && !fileName.endsWith('.json')) {
             alert('Поддерживаются только .jsonl и .json файлы');
             return;
         }
         const reader = new FileReader();
         reader.onload = (e) => {
+            const prevEntities = new Map(DataModel.entities);
+            const prevRelations = [...DataModel.relations];
+            const prevStats = { ...DataModel._stats };
             DataModel.loadFromText(e.target.result);
             if (DataModel.entities.size === 0) {
+                // Restore previous state
+                DataModel.entities = prevEntities;
+                DataModel.relations = prevRelations;
+                DataModel._stats = prevStats;
                 alert('Файл не содержит данных или имеет неверный формат');
                 return;
             }
@@ -1023,7 +1024,14 @@
 
         // File input
         const fileInput = document.getElementById('file-input');
-        document.getElementById('upload-area').addEventListener('click', () => fileInput.click());
+        const uploadArea = document.getElementById('upload-area');
+        uploadArea.addEventListener('click', () => fileInput.click());
+        uploadArea.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                fileInput.click();
+            }
+        });
         fileInput.addEventListener('change', (e) => handleFile(e.target.files[0]));
 
         // Buttons
@@ -1048,14 +1056,20 @@
         const overlay = document.getElementById('dropzone-overlay');
         let dragCounter = 0;
 
+        function isFileDrag(e) {
+            return e.dataTransfer && e.dataTransfer.types && e.dataTransfer.types.includes('Files');
+        }
+
         document.addEventListener('dragenter', (e) => {
             e.preventDefault();
+            if (!isFileDrag(e)) return;
             dragCounter++;
             overlay.style.display = 'flex';
         });
 
         document.addEventListener('dragleave', (e) => {
             e.preventDefault();
+            if (!isFileDrag(e)) return;
             dragCounter--;
             if (dragCounter <= 0) {
                 dragCounter = 0;

--- a/memory.jsonl
+++ b/memory.jsonl
@@ -1,0 +1,27 @@
+{"type":"entity","name":"server-memory-editor","entityType":"project","observations":["Веб-визуализатор и редактор для файлов memory.jsonl от MCP server-memory","Один файл index.html, D3.js v7 с CDN, без фреймворков","Репозиторий: github.com/oshliaer/server-memory-editor","Фаза 1 (viewer) реализована, фазы 2 (CRUD) и 3 (MCP-интеграция) запланированы","Архитектура: DataModel (мутабельный state) + Renderer (D3) + UI (обработчики)","Фаза 1 (viewer MVP) завершена: парсинг JSONL, D3 граф, интерактивность, поиск, экспорт","Исправлены баги оригинала: dangling relations (ghost-ноды), дубликаты (merge+count), укорочение стрелок (динамическое refX)","Created: package.json, CHANGELOG.md, README.md","Версия: 0.1.1 (patch-релиз от 2026-03-28)","Улучшения UI: исправлен баг fitToView, двухстрочный layout relation items, кликабельные версии дубликатов","Добавлена интерактивность: фильтры ghost/dup в статистике панели, просмотр оригинальных версий дубликатов","Улучшено хранение: DataModel сохраняет _versions с оригинальными entityType и observations дубликатов","Issue #11: улучшено отображение дубликатов и призраков"]}
+{"type":"entity","name":"mcp-memory-visualizer","entityType":"reference","observations":["Оригинальный визуализатор, взятый за основу для реверс-инжиниринга","Автор: dzivkovi, репозиторий: github.com/dzivkovi/mcp-memory-visualizer","Демо: dzivkovi.github.io/mcp-memory-visualizer/","Баги: crash на dangling relations, дублирование нод, хардкод refX=25 для стрелок","Использует D3.js, светлую тему, welcome screen"]}
+{"type":"entity","name":"mcp-server-memory","entityType":"dependency","observations":["MCP-сервер для управления knowledge graph через JSONL файлы","Репозиторий: github.com/modelcontextprotocol/servers/tree/main/src/memory","Операции: create_entities, delete_entities, add_observations, delete_observations, create_relations, delete_relations, search_nodes, open_nodes, read_graph","Формат: JSONL — entity {type,name,entityType,observations} и relation {type,from,to,relationType}","entityType и relationType — freeform строки без валидации"]}
+{"type":"entity","name":"D3.js","entityType":"technology","observations":["Библиотека визуализации данных, v7.8.5","Подключается с CDN: cdnjs.cloudflare.com","Используется для force-directed графа, zoom/pan, drag, SVG-рендеринга"]}
+{"type":"entity","name":"зонтичный-issue-7","entityType":"tracker","observations":["GitHub issue #7: Memory JSONL Visualizer & Editor","Содержит чеклист всех 3 фаз проекта","Фаза 1: issues #1-#6 (viewer MVP)","Фаза 2: CRUD-редактирование (локальное)","Фаза 3: MCP-интеграция"]}
+{"type":"entity","name":"issue-8-entity-types","entityType":"tracker","observations":["GitHub issue #8: Продумать интерактивность Entity Types","Направления: фильтрация по легенде, hover-подсветка, группировка, кастомные цвета"]}
+{"type":"entity","name":"issue-9-relation-types","entityType":"tracker","observations":["GitHub issue #9: Продумать интерактивность Relation Types","relationType — freeform, до 96 уникальных значений в реальных данных","Проблемы: не влезут в легенду, длинные фразы не влезут на ребро"]}
+{"type":"entity","name":"D3.js","entityType":"technology","observations":["Основа для визуализации графов в браузере"]}
+{"type":"entity","name":"D3.js","entityType":"library","observations":["Поддерживает SVG, Canvas, HTML рендеринг","Модульная архитектура: d3-force, d3-selection, d3-zoom"]}
+{"type":"entity","name":"D3.js","entityType":"technology","observations":["Документация: d3js.org","Лицензия: ISC"]}
+{"type":"entity","name":"mcp-server-memory","entityType":"dependency","observations":["Часть официального набора MCP серверов от Anthropic"]}
+{"type":"entity","name":"mcp-server-memory","entityType":"service","observations":["Хранит данные в одном файле memory.jsonl","Запускается через stdio transport"]}
+{"type":"entity","name":"mcp-server-memory","entityType":"dependency","observations":["Поддерживает поиск по именам, типам и наблюдениям"]}
+{"type":"entity","name":"mcp-server-memory","entityType":"tool","observations":["Альтернативная запись с другим entityType","Используется Claude Desktop и Claude Code"]}
+{"type":"relation","from":"server-memory-editor","to":"mcp-memory-visualizer","relationType":"reverse-engineered from"}
+{"type":"relation","from":"server-memory-editor","to":"mcp-server-memory","relationType":"visualizes data from"}
+{"type":"relation","from":"server-memory-editor","to":"D3.js","relationType":"uses"}
+{"type":"relation","from":"mcp-memory-visualizer","to":"D3.js","relationType":"uses"}
+{"type":"relation","from":"mcp-memory-visualizer","to":"mcp-server-memory","relationType":"visualizes data from"}
+{"type":"relation","from":"зонтичный-issue-7","to":"server-memory-editor","relationType":"tracks"}
+{"type":"relation","from":"issue-8-entity-types","to":"server-memory-editor","relationType":"enhances"}
+{"type":"relation","from":"issue-9-relation-types","to":"server-memory-editor","relationType":"enhances"}
+{"type":"relation","from":"server-memory-editor","to":"GitHub Pages","relationType":"deployed via"}
+{"type":"relation","from":"D3.js","to":"Mike Bostock","relationType":"created by"}
+{"type":"relation","from":"D3.js","to":"Observable","relationType":"maintained by"}
+{"type":"relation","from":"mcp-server-memory","to":"Anthropic","relationType":"developed by"}
+{"type":"relation","from":"mcp-server-memory","to":"Claude Desktop","relationType":"integrates with"}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-memory-editor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Web visualizer and editor for MCP server-memory JSONL files",
   "main": "index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "server-memory-editor",
+  "version": "0.1.0",
+  "description": "Web visualizer and editor for MCP server-memory JSONL files",
+  "main": "index.html",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oshliaer/server-memory-editor"
+  },
+  "keywords": [
+    "memory",
+    "jsonl",
+    "visualizer",
+    "editor",
+    "d3",
+    "graph"
+  ],
+  "author": "oshliaer",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- Phase 1 viewer for `memory.jsonl` files from MCP server-memory
- Single `index.html` with D3.js v7 force-directed graph
- Architecture: DataModel (mutable state) + Renderer (D3) + UI (handlers)

### Features
- Load `.jsonl`/`.json` via file picker or drag-and-drop (document-level)
- Force-directed graph: color by entityType (Tableau10), size by observations count
- Click node → details panel with clickable relations (graph navigation)
- Neighbor highlight + dimming of unrelated nodes
- Search by name, entityType, observations
- Legend, statistics (entities/relations/duplicates/ghosts)
- Export cleaned `.jsonl` (merged duplicates, no ghost nodes)
- Fit-to-view on simulation end

### Bug fixes vs original (dzivkovi/mcp-memory-visualizer)
- Dangling relations no longer crash → ghost nodes with dashed stroke
- Duplicate entities merged (observations union) instead of duplicated
- Arrow markers respect variable node radius (shortened lines in ticked())
- No welcome/landing page — straight to visualizer
- Two-line relation layout in details panel (name + type)

## Test plan
- [x] Open `index.html` in browser
- [x] Drag-and-drop `memory.jsonl` → graph renders without console errors
- [x] Verify ghost nodes (dashed) for dangling relations
- [x] Verify duplicate merge: thick stroke, "Встречается N раз" in details
- [x] Click node → details panel → click related entity → navigation works
- [x] Neighbor highlighting: unrelated nodes dimmed
- [x] Search filters nodes
- [x] Export downloads valid `.jsonl`
- [x] Zoom/pan/drag work correctly

Closes #1, #2, #3, #4, #5, #6
Relates to #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detail panel: clickable “Found N times — show versions” to inspect original duplicate versions
  * Two-line entity/relation layout (name + smaller relation/type line)
  * Clickable “N dup” / “N ghost” stats filters that toggle/reset graph view
  * Import via drag-and-drop or file picker; export current graph as JSONL; Escape to deselect
  * Sample memory dataset included for quick loading

* **Bug Fixes**
  * Fit-to-view runs only once on initial load

* **Documentation**
  * Added README and CHANGELOG entries for v0.1.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->